### PR TITLE
base64エンコードした鍵を利用できるように修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.0.1'
+version = '1.0.2'
 description = '暗号化機能'
 
 
@@ -25,7 +25,7 @@ sourceCompatibility=JavaVersion.VERSION_1_6
 targetCompatibility=JavaVersion.VERSION_1_6
 
 dependencies {
-  compile "com.nablarch.framework:nablarch-core-validation:${nablarchCoreValidationVersion}"
+  compile "com.nablarch.framework:nablarch-fw:${nablarchFwVersion}"
   
   testCompile 'junit:junit:4.12'
   testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/src/main/java/nablarch/common/encryption/Base64Key.java
+++ b/src/main/java/nablarch/common/encryption/Base64Key.java
@@ -1,0 +1,55 @@
+package nablarch.common.encryption;
+
+import nablarch.core.util.Base64Util;
+
+/**
+ * Base64エンコードされた鍵を持つクラス。
+ *
+ * @author siosio
+ */
+public class Base64Key {
+
+    /** 暗号化に使用する共通鍵(128bit) */
+    private byte[] key;
+
+    /** 暗号化に使用するIV(イニシャルバリュー)(128bit) */
+    private byte[] iv;
+
+    /**
+     * 暗号化に使用する共通鍵(128bit)を設定する。
+     * <p>
+     * Base64エンコードされた鍵を設定すること。
+     *
+     * @param key 暗号化に使用する共通鍵(128bit)
+     */
+    public void setKey(final String key) {
+        this.key = Base64Util.decode(key);
+    }
+
+    /**
+     * 暗号化に使用するIV(128bit)を設定する。
+     * <p>
+     * Base64エンコードされたIVを設定すること。
+     *
+     * @param iv 暗号化に使用するIV(128bit)
+     */
+    public void setIv(final String iv) {
+        this.iv = Base64Util.decode(iv);
+    }
+
+    /**
+     * 共通鍵(128bit)を返す。
+     * @return 共通鍵(128bit)
+     */
+    public byte[] getKey() {
+        return key;
+    }
+
+    /**
+     * IV(128bit)を返す。
+     * @return IV(128bit)
+     */
+    public byte[] getIv() {
+        return iv;
+    }
+}


### PR DESCRIPTION
* 既存の鍵とIVを設定するメソッドは非推奨に変更

NAB-83 AesEncryptorの鍵をbase64で設定できるようにする